### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/homeProfiles/common/common.nix
+++ b/homeProfiles/common/common.nix
@@ -39,6 +39,6 @@ in rec {
   # Nicely reload system units when changing configs
   systemd.user.startServices = "sd-switch";
 
-  # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+  # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
   home.stateVersion = "23.11";
 }

--- a/homeProfiles/graphical/graphical.nix
+++ b/homeProfiles/graphical/graphical.nix
@@ -114,7 +114,7 @@ args @ {
   };
 
   # Declaratively configure connection of virt-manager to libvirtd QEMU/KVM
-  # https://nixos.wiki/wiki/Virt-manager
+  # https://wiki.nixos.org/wiki/Virt-manager
   dconf.settings = {
     "org/virt-manager/virt-manager/connections" = {
       autoconnect = ["qemu:///system"];

--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -577,8 +577,8 @@ in {
                     };
 
                     "NixOS Wiki" = {
-                      urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}"; }];
-                      iconUpdateURL = "https://wiki.nixos.org/favicon.png";
+                      urls = [{ template = "https://wiki.nixos.org/w/index.php?search={searchTerms}"; }];
+                      iconUpdateURL = "https://wiki.nixos.org/nixos.png";
                       updateInterval = 24 * 60 * 60 * 1000; # every day
                       definedAliases = [ "@nw" ];
                     };

--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -491,7 +491,7 @@ in {
                       {
                         name = "wiki";
                         tags = [ "wiki" "nix" ];
-                        url = "https://nixos.wiki/";
+                        url = "https://wiki.nixos.org/";
                       }
                     ];
                   }
@@ -577,8 +577,8 @@ in {
                     };
 
                     "NixOS Wiki" = {
-                      urls = [{ template = "https://nixos.wiki/index.php?search={searchTerms}"; }];
-                      iconUpdateURL = "https://nixos.wiki/favicon.png";
+                      urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}"; }];
+                      iconUpdateURL = "https://wiki.nixos.org/favicon.png";
                       updateInterval = 24 * 60 * 60 * 1000; # every day
                       definedAliases = [ "@nw" ];
                     };

--- a/nixosProfiles/common/common.nix
+++ b/nixosProfiles/common/common.nix
@@ -80,6 +80,6 @@
   programs.git.enable = true;
   programs.git.lfs.enable = true;
 
-  # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+  # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
   system.stateVersion = "23.11";
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,7 +9,7 @@ args @ {
 
   # This one contains whatever you want to overlay
   # You can change versions, add patches, set compilation flags, anything really.
-  # https://nixos.wiki/wiki/Overlays
+  # https://wiki.nixos.org/wiki/Overlays
   #modifications = final: prev: ""; #{
   # example = prev.example.overrideAttrs (oldAttrs: rec {
   # ...


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️